### PR TITLE
Feat: Implement Black-Scholes GEX & separate Vol/OI plots

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -1,5 +1,177 @@
 import pandas as pd
 import numpy as np
+from scipy.stats import norm
+import datetime # Required for date calculations if DTE is not directly available
+
+def calculate_black_scholes_gamma(S, K, T, r, sigma):
+    """
+    Calculates the Black-Scholes Gamma for an option.
+    S: Current price of the underlying asset
+    K: Strike price of the option
+    T: Time to expiration (in years)
+    r: Risk-free interest rate (annualized)
+    sigma: Volatility of the underlying asset (annualized)
+    """
+    # Ensure inputs are array-like for vectorized operations
+    S = np.asarray(S)
+    K = np.asarray(K)
+    T = np.asarray(T)
+    r = np.asarray(r)
+    sigma = np.asarray(sigma)
+
+    # Initialize gamma array with NaNs or zeros
+    gamma = np.full_like(S, np.nan, dtype=np.double)
+
+    # Avoid calculations for invalid inputs (T=0, sigma=0, S=0)
+    valid_mask = (T > 1e-6) & (sigma > 1e-6) & (S > 1e-6) # Use a small epsilon for T, sigma, S > 0
+
+    if np.any(valid_mask):
+        S_valid = S[valid_mask]
+        K_valid = K[valid_mask]
+        T_valid = T[valid_mask]
+        r_valid = r[valid_mask] if np.isscalar(r) else r[valid_mask] # handle scalar r
+        sigma_valid = sigma[valid_mask] if np.isscalar(sigma) else sigma[valid_mask] # handle scalar sigma
+
+        d1_numerator = np.log(S_valid / K_valid) + (r_valid + 0.5 * sigma_valid**2) * T_valid
+        d1_denominator = sigma_valid * np.sqrt(T_valid)
+
+        # Avoid division by zero in d1_denominator
+        d1 = np.full_like(S_valid, np.nan, dtype=np.double)
+        denom_valid_mask = (d1_denominator > 1e-9) # Check denominator is not too small
+
+        d1[denom_valid_mask] = d1_numerator[denom_valid_mask] / d1_denominator[denom_valid_mask]
+        d1[~denom_valid_mask] = np.inf * np.sign(d1_numerator[~denom_valid_mask]) # Handle case for very small sigma*sqrt(T)
+
+        phi_d1 = norm.pdf(d1)
+
+        gamma_denominator = S_valid * sigma_valid * np.sqrt(T_valid)
+        gamma_calc = np.full_like(S_valid, np.nan, dtype=np.double)
+
+        gamma_denom_valid_mask = (gamma_denominator > 1e-9)
+        gamma_calc[gamma_denom_valid_mask] = phi_d1[gamma_denom_valid_mask] / gamma_denominator[gamma_denom_valid_mask]
+
+        gamma[valid_mask] = gamma_calc
+
+    return gamma
+
+def calculate_gex_analytics(df_options_original, current_spot_price, risk_free_rate, calculation_date=None):
+    """
+    Calculates Gamma Exposure by Strike, Aggregate Gamma Exposure Curve, and Gamma Flip Point.
+    """
+    if df_options_original is None or df_options_original.empty:
+        return None, None, np.nan, np.nan
+
+    if not all(col in df_options_original.columns for col in ['Strike', 'Open Int', 'Type', 'IV']):
+        print("Missing one or more required columns: 'Strike', 'Open Int', 'Type', 'IV'")
+        return None, None, np.nan, np.nan
+    if 'Exp Date' not in df_options_original.columns and 'DTE' not in df_options_original.columns:
+        print("Missing 'Exp Date' or 'DTE' column for time to maturity calculation.")
+        return None, None, np.nan, np.nan
+
+    df = df_options_original.copy()
+
+    # Ensure 'Type' is lowercase
+    df['Type'] = df['Type'].str.lower()
+
+    # Part A: Calculate Gamma for each contract using current_spot_price
+    if calculation_date is None:
+        calculation_date = pd.Timestamp('today').normalize()
+    else:
+        calculation_date = pd.to_datetime(calculation_date).normalize()
+
+    if 'DTE' not in df.columns:
+        if 'Exp Date' not in df.columns:
+             raise ValueError("DataFrame must have either 'DTE' or 'Exp Date' column.")
+        df['Exp Date'] = pd.to_datetime(df['Exp Date'])
+        df['DTE'] = (df['Exp Date'] - calculation_date).dt.days
+
+    df['T_years'] = df['DTE'] / 365.25
+
+    # Filter out expired or invalid options for Gamma calculation
+    valid_options_for_gamma = df[df['T_years'] > 1e-6].copy() # Small epsilon to avoid T=0 issues
+    if valid_options_for_gamma.empty:
+        print("No valid options with T_years > 0 for Gamma calculation.")
+        return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
+
+    valid_options_for_gamma['Calculated_Gamma'] = calculate_black_scholes_gamma(
+        S=current_spot_price,
+        K=valid_options_for_gamma['Strike'],
+        T=valid_options_for_gamma['T_years'],
+        r=risk_free_rate,
+        sigma=valid_options_for_gamma['IV'] # Assumes IV is already in decimal form
+    )
+    valid_options_for_gamma.dropna(subset=['Calculated_Gamma'], inplace=True) # Remove rows where gamma calc failed
+
+    # Part B: Calculate Gamma Exposure by Strike (for the bars)
+    valid_options_for_gamma['GEX_Contract_Value'] = valid_options_for_gamma['Calculated_Gamma'] * valid_options_for_gamma['Open Int'] * 100
+    valid_options_for_gamma['GEX_Signed_Value'] = np.where(
+        valid_options_for_gamma['Type'] == 'call',
+        valid_options_for_gamma['GEX_Contract_Value'],
+        -valid_options_for_gamma['GEX_Contract_Value']
+    )
+
+    if valid_options_for_gamma.empty: # Check again after gamma calculation and signing
+        gex_bars_data = pd.DataFrame({'Strike': [], 'GEX_Signed_Value': []})
+        net_gex_at_current_price = 0
+    else:
+        gex_bars_data = valid_options_for_gamma.groupby('Strike')['GEX_Signed_Value'].sum().reset_index()
+        net_gex_at_current_price = gex_bars_data['GEX_Signed_Value'].sum()
+
+
+    # Part C: Calculate Aggregate Gamma Exposure Curve and Flip Point
+    # Use all options from the original valid_options_for_gamma for simulation, as T_years remains constant for this part
+    # We need df_copy of valid_options_for_gamma to ensure T_years and other necessary columns are present
+    sim_df = valid_options_for_gamma.copy()
+
+    min_price = current_spot_price * 0.80
+    max_price = current_spot_price * 1.20
+    # Ensure step is reasonable, avoid too many points if price range is huge, or too few if small
+    price_step = max(0.1, round((max_price - min_price) / 100, 2)) # Aim for around 100-200 points
+    if price_step == 0: price_step = 0.5 # Default if range is tiny
+
+    test_price_range = np.arange(min_price, max_price + price_step, price_step) # + price_step to include upper bound
+
+    simulated_gex_totals = []
+
+    for s_sim in test_price_range:
+        # Recalculate gamma for all options at this s_sim
+        gamma_sim = calculate_black_scholes_gamma(
+            S=s_sim,
+            K=sim_df['Strike'],
+            T=sim_df['T_years'],
+            r=risk_free_rate,
+            sigma=sim_df['IV']
+        )
+
+        gex_contract_sim = gamma_sim * sim_df['Open Int'] * 100
+        gex_signed_sim = np.where(sim_df['Type'] == 'call', gex_contract_sim, -gex_contract_sim)
+        total_gex_for_s_sim = np.nansum(gex_signed_sim) # Use nansum in case any gamma_sim was NaN
+
+        simulated_gex_totals.append({'Simulated_Price': s_sim, 'Total_GEX': total_gex_for_s_sim})
+
+    df_aggregate_curve = pd.DataFrame(simulated_gex_totals)
+    df_aggregate_curve.sort_values(by='Simulated_Price', inplace=True) # Ensure it's sorted for flip point logic
+
+    # Find Gamma Flip Point
+    gamma_flip_price = np.nan
+    prev_gex = None
+    prev_price = None
+    for index, row in df_aggregate_curve.iterrows():
+        current_gex = row['Total_GEX']
+        current_price = row['Simulated_Price']
+        if prev_gex is not None:
+            if prev_gex < 0 and current_gex >= 0:
+                # Linear interpolation for a more precise flip point
+                if (current_gex - prev_gex) != 0: # Avoid division by zero
+                    gamma_flip_price = prev_price - prev_gex * (current_price - prev_price) / (current_gex - prev_gex)
+                else:
+                    gamma_flip_price = (prev_price + current_price) / 2 # Fallback to midpoint
+                break
+        prev_gex = current_gex
+        prev_price = current_price
+
+    return gex_bars_data, df_aggregate_curve, gamma_flip_price, net_gex_at_current_price
+
 
 def calculate_put_call_ratio(df, value_col, type_col='Type', strike_col='Strike', call_label='call', put_label='put'):
     """
@@ -12,37 +184,29 @@ def calculate_put_call_ratio(df, value_col, type_col='Type', strike_col='Strike'
     df_copy = df.copy()
     df_copy[type_col] = df_copy[type_col].str.lower()
 
-    # Total P/C Ratio
     total_calls_value = df_copy[df_copy[type_col] == call_label][value_col].sum()
     total_puts_value = df_copy[df_copy[type_col] == put_label][value_col].sum()
 
     total_pc_ratio = total_puts_value / total_calls_value if total_calls_value > 0 else np.nan
 
-    # P/C Ratio per Strike
     pc_ratio_by_strike = None
     if strike_col in df_copy.columns:
         calls_by_strike = df_copy[df_copy[type_col] == call_label].groupby(strike_col)[value_col].sum()
         puts_by_strike = df_copy[df_copy[type_col] == put_label].groupby(strike_col)[value_col].sum()
 
         pc_df = pd.DataFrame({'calls': calls_by_strike, 'puts': puts_by_strike}).fillna(0)
-        pc_df['pc_ratio'] = pc_df['puts'] / pc_df['calls'].replace(0, np.nan) # Avoid division by zero
+        pc_df['pc_ratio'] = pc_df['puts'] / pc_df['calls'].replace(0, np.nan)
         pc_ratio_by_strike = pc_df.reset_index()
 
     return total_pc_ratio, pc_ratio_by_strike
 
 def calculate_money_at_risk(df, oi_col='Open Int', mid_price_col='Mid', type_col='Type', strike_col='Strike', multiplier=100):
-    """
-    Calculates Money at Risk for options.
-    Money at Risk = Open Interest * Option Mid Price * Multiplier
-    Returns DataFrame with money at risk per strike for calls and puts.
-    """
     if df is None or df.empty or not all(col in df.columns for col in [oi_col, mid_price_col, type_col, strike_col]):
         return None
 
     df_copy = df.copy()
     df_copy['money_at_risk'] = df_copy[oi_col] * df_copy[mid_price_col] * multiplier
 
-    # Sum money at risk for calls and puts separately per strike
     money_at_risk_summary = df_copy.groupby([strike_col, type_col])['money_at_risk'].sum().unstack(fill_value=0)
     money_at_risk_summary = money_at_risk_summary.rename(
         columns=lambda x: f'{x.lower()}_money_at_risk'
@@ -51,185 +215,57 @@ def calculate_money_at_risk(df, oi_col='Open Int', mid_price_col='Mid', type_col
     return money_at_risk_summary
 
 def calculate_max_pain(df_cadena, strike_col='Strike', oi_col='Open Int', type_col='Type', call_label='call', put_label='put', multiplier=100):
-    """
-    Calculates the Max Pain strike.
-    Max Pain is the strike price at which the most option holders (buyers) would lose money if the stock expired at that price.
-    This means it's the strike where the intrinsic value of all open options (Calls and Puts) is minimized.
-    """
     if df_cadena is None or df_cadena.empty or not all(col in df_cadena.columns for col in [strike_col, oi_col, type_col]):
         return None
 
-    strikes = sorted(df_cadena[strike_col].unique())
-    max_pain_data = []
+    unique_strikes = sorted(df_cadena[strike_col].unique())
+    if not unique_strikes:
+        return None, None
 
-    for expiry_price in strikes:
-        total_loss = 0
+    cash_values_at_expiry = []
 
-        # Calculate loss for Calls
-        calls = df_cadena[(df_cadena[type_col].str.lower() == call_label) & (df_cadena[strike_col] < expiry_price)]
-        total_loss += ( (expiry_price - calls[strike_col]) * calls[oi_col] * multiplier ).sum()
+    for expiry_price in unique_strikes:
+        total_value_if_expired_at_strike = 0
 
-        # Calculate loss for Puts
-        puts = df_cadena[(df_cadena[type_col].str.lower() == put_label) & (df_cadena[strike_col] > expiry_price)]
-        total_loss += ( (puts[strike_col] - expiry_price) * puts[oi_col] * multiplier ).sum()
+        calls = df_cadena[df_cadena[type_col].str.lower() == call_label]
+        intrinsic_value_calls = np.maximum(0, expiry_price - calls[strike_col]) * calls[oi_col] * multiplier
+        total_value_if_expired_at_strike += intrinsic_value_calls.sum()
 
-        max_pain_data.append({'strike': expiry_price, 'total_value_at_expiry': total_loss})
+        puts = df_cadena[df_cadena[type_col].str.lower() == put_label]
+        intrinsic_value_puts = np.maximum(0, puts[strike_col] - expiry_price) * puts[oi_col] * multiplier
+        total_value_if_expired_at_strike += intrinsic_value_puts.sum()
 
-    if not max_pain_data:
-        return None
+        cash_values_at_expiry.append({'strike_price_at_expiry': expiry_price, 'total_option_value': total_value_if_expired_at_strike})
 
-    max_pain_df = pd.DataFrame(max_pain_data)
+    if not cash_values_at_expiry:
+        return None, None
 
-    # Max pain is the strike with the minimum total value (loss for holders, gain for sellers)
-    # However, the traditional definition refers to the value of options that would expire worthless or with value.
-    # Let's redefine to calculate cash value of options if stock expires at 'expiry_price'
-
-    cash_values = []
-    for test_strike in strikes:
-        current_cash_value = 0
-        # For calls: if stock_price > strike_price, value is (stock_price - strike_price) * OI
-        calls_df = df_cadena[df_cadena[type_col].str.lower() == call_label]
-        intrinsic_calls = np.maximum(0, test_strike - calls_df[strike_col]) * calls_df[oi_col]
-        current_cash_value += intrinsic_calls.sum()
-
-        # For puts: if stock_price < strike_price, value is (strike_price - stock_price) * OI
-        puts_df = df_cadena[df_cadena[type_col].str.lower() == put_label]
-        intrinsic_puts = np.maximum(0, puts_df[strike_col] - test_strike) * puts_df[oi_col]
-        current_cash_value += intrinsic_puts.sum()
-
-        cash_values.append({'strike_price_at_expiry': test_strike, 'total_option_value': current_cash_value * multiplier})
-
-    if not cash_values:
-        return None
-
-    cash_values_df = pd.DataFrame(cash_values)
-    max_pain_strike = cash_values_df.loc[cash_values_df['total_option_value'].idxmin()]['strike_price_at_expiry']
+    cash_values_df = pd.DataFrame(cash_values_at_expiry)
+    max_pain_strike_info = cash_values_df.loc[cash_values_df['total_option_value'].idxmin()]
+    max_pain_strike = max_pain_strike_info['strike_price_at_expiry']
 
     return max_pain_strike, cash_values_df
 
 
-def calculate_gex_and_flip(df_griegas, underlying_price_col='Underlying_Price', oi_col='Open Int',
-                           gamma_col='Gamma', type_col='Type', strike_col='Strike',
-                           call_label='call', put_label='put', per_share_gex=False):
-    """
-    Calculates Gross Gamma Exposure (GEX) and per-strike Gamma.
-    GEX = Sum of (Gamma * Open Interest * 100 * (Underlying Price^2) * 0.01) for Calls
-          - Sum of (Gamma * Open Interest * 100 * (Underlying Price^2) * 0.01) for Puts.
-    The (Underlying Price^2 * 0.01) part is for dollar gamma. If per_share_gex is True, this is omitted.
-    Also identifies potential Gamma Flip Point by looking at GEX across a range of potential underlying prices.
-    """
-    if df_griegas is None or df_griegas.empty or not all(col in df_griegas.columns for col in [oi_col, gamma_col, type_col, strike_col]):
-        return None, None, None
-
-    df = df_griegas.copy()
-    df[type_col] = df[type_col].str.lower()
-
-    # Calculate GEX per option contract
-    # Positive Gamma for long calls and long puts.
-    # Market makers are typically short gamma, so their exposure is opposite.
-    # GEX here is defined from the perspective of option holders (long gamma).
-    # For market maker exposure, flip the sign or adjust interpretation.
-    # The definition given in the prompt "If the GEX neta is positiva, los market makers estabilizan el precio"
-    # suggests GEX is viewed from the market maker's perspective (short gamma).
-    # So, long calls (positive gamma for holder) = negative gamma exposure for MM.
-    # Long puts (positive gamma for holder) = negative gamma exposure for MM.
-    # Let's calculate dealer GEX:
-    # Dealer Gamma for Calls = -Gamma * OI * 100 (gamma is per share, OI is per 100 shares)
-    # Dealer Gamma for Puts = -Gamma * OI * 100
-
-    # Standard GEX calculation often sums Call Gamma and subtracts Put Gamma, assuming retail is long.
-    # Or, if looking at dealer exposure which is short options:
-    # GEX = OI * Gamma * 100 (for calls)  <-- this is dealer exposure if they sold calls
-    # GEX = OI * Gamma * 100 (for puts)   <-- this is dealer exposure if they sold puts
-    # If dealer is short calls, their gamma is negative. If short puts, their gamma is negative.
-    # Net GEX = sum(OI * Gamma * 100 * Multiplier_for_Notional)
-    # Let's use the common definition: Call Gamma - Put Gamma (scaled by OI)
-    # This usually means (OI_call * Gamma_call) - (OI_put * Gamma_put)
-    # The prompt's "GEX neta positiva -> market makers estabilizan" implies we are calculating market maker gamma.
-    # If market makers are short calls, their gamma is -Gamma_call. If short puts, -Gamma_put.
-    # So, GEX_dealer = sum(-Gamma_call * OI_call * 100) + sum(-Gamma_put * OI_put * 100)
-    # This is total negative gamma.
-    # Let's stick to the user's definition for now and assume GEX is calculated in a way that
-    # positive GEX means dealers buy on dips and sell on rallies.
-
-    # Gamma exposure per strike (dealer perspective, short options)
-    # For a dealer short a call: exposure = -Gamma * OI * 100
-    # For a dealer short a put: exposure = -Gamma * OI * 100
-    # So, total dealer GEX = sum(-Gamma * OI * 100) for all options.
-    # The "per_share_gex" factor for dollar gamma: * Underlying Price^2 * 0.01 for dollar gamma notional
-    # Or simply $ per 1% move: Gamma * OI * 100 * Underlying_Price * 0.01
-
-    # Let's use a common definition for GEX:
-    # GEX_per_strike = OI * Gamma * 100 (this is share gamma, not dollar gamma)
-    # For Calls, this is positive. For Puts, this is also positive (as Gamma is positive for long options).
-    # The "flip" comes from how calls and puts influence dealer hedging.
-    # Dealers hedge delta. If they are short calls (delta negative), they buy stock. If price goes up, delta increases (becomes less negative), they buy more.
-    # If they are short puts (delta positive), they sell stock. If price goes up, delta decreases (becomes less positive), they buy back stock.
-
-    # A common way to calculate GEX representing dealer impact:
-    # GEX = sum over Calls (OI * Gamma * 100) - sum over Puts (OI * Gamma * 100)
-    # This is often scaled by notional value (Underlying Price).
-
-    # Let's use the formula that aligns with "positive GEX = stabilizing":
-    # GEX_strike = Gamma * OI * 100
-    # If Type is Put, multiply by -1 for the GEX calculation to represent dealer hedging flow.
-    # (This is one interpretation for GEX where positive means stability)
-    df['strike_gex_contribution'] = df[gamma_col] * df[oi_col] * 100
-    df['strike_gex_contribution'] = df.apply(
-        lambda row: -row['strike_gex_contribution'] if row[type_col] == put_label else row['strike_gex_contribution'],
-        axis=1
-    )
-    # This GEX means: if price rises, positive GEX dealers sell (counter-trend), negative GEX dealers buy (pro-trend).
-    # So, if GEX is positive, dealers are delta hedging in a way that dampens moves.
-    # If GEX is negative, dealers are delta hedging in a way that amplifies moves.
-
-    if not per_share_gex and underlying_price_col in df.columns and df[underlying_price_col].iloc[0] > 0:
-        # Convert to dollar gamma exposure (approximate): GEX_shares * Underlying_Price
-        # More precise $Gamma: Gamma * OI * 100 * (Underlying_Price^2) * 0.01 for $ change per 1% move in underlying
-        # Or $ per 1 point move in underlying: Gamma * OI * 100 * Underlying_Price
-        # Let's use the $ per 1% move interpretation for now for the notional GEX.
-        # Actually, GEX is often quoted in $MM per 1% move.
-        # GEX ($) = Gamma * OI * 100 * (Underlying Price)^2 * 0.01
-        # Let's use the simpler definition first: GEX in shares.
-        # The prompt implies GEX is a value that flips sign.
-        pass # Using share GEX for now. Can be scaled later.
-
-    gex_by_strike = df.groupby(strike_col)['strike_gex_contribution'].sum().reset_index()
-    gex_by_strike = gex_by_strike.rename(columns={'strike_gex_contribution': 'gex'})
-
-    total_gex = gex_by_strike['gex'].sum()
-
-    # Gamma Flip Point:
-    # This requires simulating GEX at different underlying prices, as Gamma itself changes with stock price and IV.
-    # For a simplified "static" flip point based on current gamma values:
-    # Find where cumulative GEX (summed from low strikes up) changes sign, or where GEX per strike changes sign.
-    # The prompt definition: "El nivel de precio donde la Exposición a Gamma neta del mercado cruza de positiva a negativa."
-    # This implies plotting Net GEX (total_gex or gex_by_strike) against the underlying price.
-    # The gex_by_strike we calculated is already against option strikes.
-    # A common way to find the "gamma flip" is to see where the GEX profile (GEX vs Strike) crosses zero.
-
-    # Find strike where GEX per strike changes sign (approximate flip)
-    # This requires gex_by_strike to be sorted by strike
-    gex_by_strike_sorted = gex_by_strike.sort_values(by=strike_col)
-    sign_changes = np.sign(gex_by_strike_sorted['gex']).diff().fillna(0).ne(0)
-    flip_points_df = gex_by_strike_sorted[sign_changes]
-
-    # A more robust Gamma Flip might be where cumulative GEX from ATM out changes sign,
-    # or requires dynamic calculation of gamma. For now, this is an indicator.
-
-    return total_gex, gex_by_strike, flip_points_df
+# This function is now superseded by calculate_gex_analytics
+# def calculate_gex_and_flip(df_griegas, underlying_price_col='Underlying_Price', oi_col='Open Int',
+#                            gamma_col='Gamma', type_col='Type', strike_col='Strike',
+#                            call_label='call', put_label='put', per_share_gex=False):
+#     pass # Obsolete
 
 
 def calculate_total_exposure(df_griegas, greek_col, oi_col='Open Int', type_col='Type', strike_col='Strike', multiplier=100):
-    """
-    Calculates total exposure for a given Greek (Vega, Theta).
-    Exposure = Greek Value * Open Interest * Multiplier (typically 100 shares/contract)
-    Theta is often negative; Vega is positive.
-    """
     if df_griegas is None or df_griegas.empty or not all(col in df_griegas.columns for col in [greek_col, oi_col, type_col, strike_col]):
         return None, None
 
     df = df_griegas.copy()
+    # Ensure the greek column is numeric, coercing errors. This is important if Gamma is pre-calculated and might have NaNs.
+    df[greek_col] = pd.to_numeric(df[greek_col], errors='coerce')
+    df.dropna(subset=[greek_col, oi_col], inplace=True) # Drop rows where essential data for calculation is missing
+
+    if df.empty: # Check if df became empty after dropping NaNs
+        return None, None
+
     df['exposure_value'] = df[greek_col] * df[oi_col] * multiplier
 
     exposure_by_strike = df.groupby(strike_col)['exposure_value'].sum().reset_index()
@@ -240,60 +276,93 @@ def calculate_total_exposure(df_griegas, greek_col, oi_col='Open Int', type_col=
 
 # Example Usage (for testing, normally called from dashboard.py)
 if __name__ == '__main__':
-    # Sample DataFrames (simplified based on structures from file_handler.py)
+    # Sample DataFrames
     cadena_dict = {
         'Strike': [50, 55, 60, 65, 70, 50, 55, 60, 65, 70],
         'Mid': [10.5, 6.0, 2.5, 0.8, 0.2, 0.3, 0.7, 2.0, 5.5, 9.8],
         'Volume': [100, 200, 500, 300, 50, 80, 150, 400, 250, 60],
         'Open Int': [1000, 1500, 3000, 2000, 500, 800, 1200, 2500, 1800, 600],
-        'Type': ['call', 'call', 'call', 'call', 'call', 'put', 'put', 'put', 'put', 'put']
+        'Type': ['call', 'call', 'call', 'call', 'call', 'put', 'put', 'put', 'put', 'put'],
+        'IV': [0.3, 0.28, 0.25, 0.27, 0.32, 0.31, 0.29, 0.26, 0.28, 0.33],
+        'Exp Date': ['2025-12-31']*10 # Example Expiry
     }
     df_cadena_sample = pd.DataFrame(cadena_dict)
+    df_cadena_sample['Exp Date'] = pd.to_datetime(df_cadena_sample['Exp Date'])
 
-    griegas_dict = {
-        'Strike': [50, 55, 60, 65, 70, 50, 55, 60, 65, 70],
-        'Open Int': [1000, 1500, 3000, 2000, 500, 800, 1200, 2500, 1800, 600],
-        'Type': ['call', 'call', 'call', 'call', 'call', 'put', 'put', 'put', 'put', 'put'],
-        'Gamma': [0.05, 0.08, 0.12, 0.07, 0.03, 0.04, 0.07, 0.11, 0.06, 0.02],
-        'Vega': [0.2, 0.3, 0.4, 0.25, 0.1, 0.18, 0.28, 0.38, 0.23, 0.08],
-        'Theta': [-0.05, -0.08, -0.10, -0.06, -0.02, -0.04, -0.07, -0.09, -0.05, -0.01],
-        'Underlying_Price': [60.5] * 10 # Assuming a static underlying price for this sample
-    }
-    df_griegas_sample = pd.DataFrame(griegas_dict)
 
-    print("--- Put/Call Ratio (Volume) ---")
+    # Test for calculate_gex_analytics
+    print("\n--- GEX Analytics (New Detailed Calculation) ---")
+    # Assuming 'Underlying_Price' would be part of a df_griegas or passed directly
+    # For this test, let's use a structure similar to what df_griegas might provide
+    # We need 'Strike', 'Open Int', 'Type', 'IV', and 'Exp Date' (or 'DTE')
+
+    # Let's use df_cadena_sample as the base for df_griegas_sample for GEX
+    df_griegas_for_gex = df_cadena_sample[['Strike', 'Open Int', 'Type', 'IV', 'Exp Date']].copy()
+    current_s = 60.0
+    risk_free_r = 0.05
+    today = pd.Timestamp('today').normalize()
+
+    # Ensure DTE is calculated for the sample data if not present
+    if 'DTE' not in df_griegas_for_gex.columns:
+        df_griegas_for_gex['DTE'] = (df_griegas_for_gex['Exp Date'] - today).dt.days
+
+    gex_bars, gex_curve, flip_price, net_gex_now = calculate_gex_analytics(
+        df_griegas_for_gex,
+        current_spot_price=current_s,
+        risk_free_rate=risk_free_r,
+        calculation_date=today
+    )
+
+    if gex_bars is not None:
+        print("GEX Bars Data (Per Strike):")
+        print(gex_bars.head())
+    if gex_curve is not None:
+        print("\nAggregate GEX Curve Data (Simulated Prices):")
+        print(gex_curve.head())
+    print(f"\nGamma Flip Price: {flip_price}")
+    print(f"Net GEX at Current Price ({current_s}): {net_gex_now}")
+
+
+    print("\n--- Put/Call Ratio (Volume) ---")
     total_pc_vol, pc_vol_strike = calculate_put_call_ratio(df_cadena_sample, value_col='Volume')
     print(f"Total P/C Ratio (Volume): {total_pc_vol}")
     if pc_vol_strike is not None: print(pc_vol_strike.head())
-
-    print("\n--- Put/Call Ratio (Open Interest) ---")
-    total_pc_oi, pc_oi_strike = calculate_put_call_ratio(df_cadena_sample, value_col='Open Int')
-    print(f"Total P/C Ratio (Open Interest): {total_pc_oi}")
-    if pc_oi_strike is not None: print(pc_oi_strike.head())
 
     print("\n--- Money at Risk ---")
     mar_df = calculate_money_at_risk(df_cadena_sample)
     if mar_df is not None: print(mar_df.head())
 
     print("\n--- Max Pain ---")
-    max_pain_strike, max_pain_df = calculate_max_pain(df_cadena_sample)
+    max_pain_strike, max_pain_df_viz = calculate_max_pain(df_cadena_sample) # Renamed to avoid conflict
     print(f"Max Pain Strike: {max_pain_strike}")
-    if max_pain_df is not None: print(max_pain_df.head())
+    if max_pain_df_viz is not None: print(max_pain_df_viz.head())
 
-    print("\n--- GEX (Gamma Exposure) ---")
-    # Note: GEX calculation can be complex and has varied definitions. This is one interpretation.
-    total_gex, gex_by_strike, flip_points = calculate_gex_and_flip(df_griegas_sample, underlying_price_col='Underlying_Price')
-    print(f"Total GEX: {total_gex}")
-    if gex_by_strike is not None: print("GEX by Strike:\n", gex_by_strike.head())
-    if flip_points is not None and not flip_points.empty: print("Potential Gamma Flip Points (Strikes):\n", flip_points)
-    else: print("No distinct Gamma Flip Points found with this data/method.")
+    # For Total Exposure, we need a 'Gamma' column if not calculating it via BS
+    # Let's assume df_griegas_for_gex now has 'Calculated_Gamma' from the GEX test
+    # For testing calculate_total_exposure, we can reuse the structure.
+    # If df_griegas_for_gex was modified in-place by calculate_gex_analytics with 'Calculated_Gamma',
+    # we might need to be careful or re-fetch/re-create.
+    # The current calculate_gex_analytics makes a copy, so df_griegas_for_gex is unchanged.
+    # For testing total_exposure for vega/theta, let's add dummy Vega/Theta to df_griegas_for_gex
+    df_griegas_for_gex['Vega'] = [0.2, 0.3, 0.4, 0.25, 0.1, 0.18, 0.28, 0.38, 0.23, 0.08] # Example Vega
+    df_griegas_for_gex['Theta'] = [-0.05, -0.08, -0.10, -0.06, -0.02, -0.04, -0.07, -0.09, -0.05, -0.01] # Example Theta
+
 
     print("\n--- Total Vega Exposure ---")
-    total_vega, vega_by_strike = calculate_total_exposure(df_griegas_sample, greek_col='Vega')
-    print(f"Total Vega Exposure: {total_vega}")
-    if vega_by_strike is not None: print(vega_by_strike.head())
+    # Ensure the greek_col passed exists in the dataframe.
+    if 'Vega' in df_griegas_for_gex.columns:
+        total_vega, vega_by_strike = calculate_total_exposure(df_griegas_for_gex, greek_col='Vega')
+        if total_vega is not None:
+            print(f"Total Vega Exposure: {total_vega}")
+        if vega_by_strike is not None: print(vega_by_strike.head())
+    else:
+        print("Vega column not found in sample data for Vega exposure calculation.")
 
     print("\n--- Total Theta Exposure (Decay) ---")
-    total_theta, theta_by_strike = calculate_total_exposure(df_griegas_sample, greek_col='Theta')
-    print(f"Total Theta Exposure: {total_theta}") # Expected to be negative
-    if theta_by_strike is not None: print(theta_by_strike.head())
+    if 'Theta' in df_griegas_for_gex.columns:
+        total_theta, theta_by_strike = calculate_total_exposure(df_griegas_for_gex, greek_col='Theta')
+        if total_theta is not None:
+            print(f"Total Theta Exposure: {total_theta}") # Expected to be negative
+        if theta_by_strike is not None: print(theta_by_strike.head())
+    else:
+        print("Theta column not found for Theta exposure calculation.")

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+import datetime # For date input default
 
 # Import functions from other modules
 import file_handler
@@ -11,20 +12,19 @@ st.set_page_config(
     page_title="Interactive Options Analysis Dashboard",
     layout="wide",
     initial_sidebar_state="expanded",
-    # Streamlit's native theme options are 'light' or 'dark'.
-    # For Plotly charts, we set template='plotly_dark' individually.
 )
-# Apply dark theme using Streamlit's capabilities if available,
-# or custom CSS. For now, relying on Plotly's dark theme for charts.
-# To enable Streamlit's dark theme by default if user OS is dark:
-# theme = {"base": "dark"} # This would go into set_page_config if supported directly like this
-# Or, use st.markdown to inject CSS for a dark theme.
-# For simplicity, we'll ensure Plotly charts use their dark theme.
-
 st.title("📊 Interactive Options Analysis Dashboard")
-st.markdown("Upload your options data CSV files to begin analysis.")
+st.markdown("Upload your options data CSV files to begin analysis. Ensure `Griegas.csv` contains `IV` (Implied Volatility) and `Exp Date` or `DTE` for GEX calculations.")
 
-# --- File Uploaders in Sidebar ---
+# --- Sidebar Inputs ---
+st.sidebar.header("Global Parameters")
+risk_free_rate = st.sidebar.number_input("Risk-Free Interest Rate (e.g., 0.05 for 5%)",
+                                         min_value=0.0, max_value=1.0, value=0.05, step=0.001, format="%.3f")
+calculation_date = st.sidebar.date_input("Calculation Date (for DTE)", value=datetime.date.today())
+# Convert calculation_date to pandas Timestamp for consistency with datetime operations in pandas
+calculation_date_ts = pd.Timestamp(calculation_date)
+
+
 st.sidebar.header("Upload Data Files")
 cadena_file = st.sidebar.file_uploader("Upload CADENA.csv (Option Chain)", type="csv")
 griegas_file = st.sidebar.file_uploader("Upload Griegas.csv (Options with Greeks)", type="csv")
@@ -32,9 +32,9 @@ inusual_file = st.sidebar.file_uploader("Upload Inusual.csv (Unusual Option Flow
 
 # --- Data Loading and Caching ---
 @st.cache_data # Use st.cache_data for dataframes
-def load_data(file, _handler_func): # Changed handler_func to _handler_func
+def load_data(file, _handler_func):
     if file:
-        df = _handler_func(file) # Use the underscored parameter
+        df = _handler_func(file)
         if df is not None and not df.empty:
             return df
     return None
@@ -47,178 +47,207 @@ df_inusual = load_data(inusual_file, file_handler.load_and_clean_inusual)
 if df_cadena is None and df_griegas is None and df_inusual is None:
     st.info("Please upload at least one CSV file to start the analysis.")
 else:
-    tab_titles = []
+    # Determine active tabs based on uploaded files
+    active_tabs = []
     if df_cadena is not None:
-        tab_titles.extend(["Overall Chain", "P/C Ratios", "Money & Max Pain"])
+        active_tabs.extend(["Chain Overview & Sentiment", "Key Levels (CADENA)"])
     if df_griegas is not None:
-        tab_titles.extend(["Greek Exposures (GEX, Vega, Theta)"])
+        active_tabs.extend(["Greek Exposures"])
     if df_inusual is not None:
-        tab_titles.extend(["Unusual Flow"])
+        active_tabs.extend(["Unusual Flow"])
 
-    if not tab_titles: # Should not happen if previous block is correct
-        st.warning("No data loaded successfully for any analysis.")
+    if not active_tabs:
+        st.warning("No data loaded successfully for any analysis. Please check file formats or content.")
+        st.stop()
 
-    tabs = st.tabs(tab_titles)
-    tab_idx = 0
+    tabs = st.tabs(active_tabs)
+    current_tab_idx = 0
 
-    # --- Tab 1: Overall Chain View (Requires CADENA.csv) ---
+    # --- Tab: Chain Overview & Sentiment (Requires CADENA.csv) ---
     if df_cadena is not None:
-        with tabs[tab_idx]:
-            st.header("⛓️ Option Chain Overview (CADENA.csv)")
-            st.dataframe(df_cadena, height=300)
+        with tabs[current_tab_idx]:
+            st.header("⛓️ Option Chain Overview & Sentiment (CADENA.csv)")
 
-            st.subheader("Volume and Open Interest by Strike")
-            # Use 'Type' from df_cadena if available, else it might raise error if not present
-            # Defaulting to 'Type' as it's expected from the CSV structure.
-            fig_vol_oi = plotting.plot_volume_oi(df_cadena, type_col='Type')
-            st.plotly_chart(fig_vol_oi, use_container_width=True)
-        tab_idx += 1
+            st.subheader("Raw Chain Data (Sample)")
+            st.dataframe(df_cadena.head(), height=200)
 
-        # --- Tab 2: Put/Call Ratios (Requires CADENA.csv) ---
-        with tabs[tab_idx]:
-            st.header(" احساس Sentiment: Put/Call Ratios (CADENA.csv)")
+            st.subheader("Volume & Open Interest by Strike")
+            col_vol, col_oi = st.columns(2)
+            with col_vol:
+                fig_vol = plotting.plot_volume_by_strike(df_cadena, type_col='Type')
+                st.plotly_chart(fig_vol, use_container_width=True)
+            with col_oi:
+                fig_oi = plotting.plot_oi_by_strike(df_cadena, type_col='Type')
+                st.plotly_chart(fig_oi, use_container_width=True)
 
-            col1, col2 = st.columns(2)
-            with col1:
-                st.subheader("Based on Volume")
+            st.subheader("Put/Call Ratios")
+            col_pcr_vol, col_pcr_oi = st.columns(2)
+            with col_pcr_vol:
                 pc_vol_total, pc_vol_strike = calculations.calculate_put_call_ratio(df_cadena, value_col='Volume', type_col='Type')
                 if pc_vol_total is not None:
                     st.metric(label="Total P/C Ratio (Volume)", value=f"{pc_vol_total:.2f}")
                 if pc_vol_strike is not None:
-                    fig_pc_vol = plotting.plot_put_call_ratio(pc_vol_strike, total_pcr=pc_vol_total, strike_col='Strike', pcr_col='pc_ratio')
+                    fig_pc_vol = plotting.plot_put_call_ratio(pc_vol_strike, total_pcr=pc_vol_total)
                     st.plotly_chart(fig_pc_vol, use_container_width=True)
                 else:
                     st.info("Not enough data for P/C Volume analysis.")
 
-            with col2:
-                st.subheader("Based on Open Interest")
+            with col_pcr_oi:
                 pc_oi_total, pc_oi_strike = calculations.calculate_put_call_ratio(df_cadena, value_col='Open Int', type_col='Type')
                 if pc_oi_total is not None:
                     st.metric(label="Total P/C Ratio (Open Interest)", value=f"{pc_oi_total:.2f}")
                 if pc_oi_strike is not None:
-                    fig_pc_oi = plotting.plot_put_call_ratio(pc_oi_strike, total_pcr=pc_oi_total, strike_col='Strike', pcr_col='pc_ratio')
+                    fig_pc_oi = plotting.plot_put_call_ratio(pc_oi_strike, total_pcr=pc_oi_total)
                     st.plotly_chart(fig_pc_oi, use_container_width=True)
                 else:
                     st.info("Not enough data for P/C Open Interest analysis.")
-        tab_idx += 1
+        current_tab_idx += 1
 
-        # --- Tab 3: Money at Risk & Max Pain (Requires CADENA.csv) ---
-        with tabs[tab_idx]:
-            st.header("💰 Key Levels: Money at Risk & Max Pain (CADENA.csv)")
+        # --- Tab: Key Levels (Requires CADENA.csv) ---
+        with tabs[current_tab_idx]:
+            st.header("💰 Key Levels Analysis (CADENA.csv)")
 
             st.subheader("Money at Risk")
-            # Ensure 'Mid' column exists, as it's used by calculate_money_at_risk
-            if 'Mid' in df_cadena.columns:
-                mar_df = calculations.calculate_money_at_risk(df_cadena, mid_price_col='Mid', type_col='Type', strike_col='Strike')
+            if 'Mid' in df_cadena.columns and 'Open Int' in df_cadena.columns and 'Strike' in df_cadena.columns and 'Type' in df_cadena.columns:
+                mar_df = calculations.calculate_money_at_risk(df_cadena, mid_price_col='Mid')
                 if mar_df is not None:
-                    fig_mar = plotting.plot_money_at_risk(mar_df, strike_col='Strike')
+                    fig_mar = plotting.plot_money_at_risk(mar_df)
                     st.plotly_chart(fig_mar, use_container_width=True)
                 else:
-                    st.info("Could not calculate Money at Risk. Check 'Mid', 'Open Int', 'Type', 'Strike' columns.")
+                    st.info("Could not calculate Money at Risk.")
             else:
-                st.warning("Column 'Mid' not found in CADENA.csv, cannot calculate Money at Risk.")
+                st.warning("Missing one or more columns ('Mid', 'Open Int', 'Strike', 'Type') needed for Money at Risk in CADENA.csv.")
 
             st.subheader("Max Pain")
-            # Max pain calculation needs Open Interest and Strike prices.
-            max_pain_strike, max_pain_df = calculations.calculate_max_pain(df_cadena, type_col='Type', strike_col='Strike')
-            if max_pain_strike is not None and max_pain_df is not None:
-                st.metric(label="Calculated Max Pain Strike", value=f"${max_pain_strike}")
-                fig_max_pain = plotting.plot_max_pain(max_pain_strike, max_pain_df, strike_price_col='strike_price_at_expiry', total_option_value_col='total_option_value')
-                st.plotly_chart(fig_max_pain, use_container_width=True)
+            if 'Open Int' in df_cadena.columns and 'Strike' in df_cadena.columns and 'Type' in df_cadena.columns:
+                max_pain_strike, max_pain_df = calculations.calculate_max_pain(df_cadena)
+                if max_pain_strike is not None and max_pain_df is not None:
+                    st.metric(label="Calculated Max Pain Strike", value=f"${max_pain_strike:.2f}")
+                    fig_max_pain = plotting.plot_max_pain(max_pain_strike, max_pain_df)
+                    st.plotly_chart(fig_max_pain, use_container_width=True)
+                else:
+                    st.info("Could not calculate Max Pain.")
             else:
-                st.info("Could not calculate Max Pain. Ensure 'Strike', 'Open Int', 'Type' columns are present and valid.")
-        tab_idx += 1
+                st.warning("Missing one or more columns ('Open Int', 'Strike', 'Type') needed for Max Pain in CADENA.csv.")
+        current_tab_idx += 1
 
-    # --- Tab 4: Greek Exposures (Requires Griegas.csv) ---
+    # --- Tab: Greek Exposures (Requires Griegas.csv) ---
     if df_griegas is not None:
-        with tabs[tab_idx]:
+        with tabs[current_tab_idx]:
             st.header("🇬🇷 Greek Exposures (Griegas.csv)")
+
+            st.subheader("Raw Griegas Data (Sample)")
             st.dataframe(df_griegas.head(), height=200)
 
-            # Assuming 'Underlying_Price' is available in df_griegas after cleaning
-            underlying_price_for_gex = df_griegas['Underlying_Price'].iloc[0] if 'Underlying_Price' in df_griegas.columns and not df_griegas.empty else None
-
-            if underlying_price_for_gex:
-                st.sidebar.info(f"Using Underlying Price: ${underlying_price_for_gex:.2f} for some Greek calculations (from Griegas.csv first row).")
+            current_spot_price = None
+            if 'Underlying_Price' in df_griegas.columns and not df_griegas.empty:
+                current_spot_price = df_griegas['Underlying_Price'].iloc[0]
+                st.sidebar.info(f"Using Underlying Price for GEX: ${current_spot_price:.2f} (from Griegas.csv first row).")
             else:
-                st.sidebar.warning("Underlying price not found in Griegas.csv. Some Greek calculations might be affected or use defaults.")
+                st.sidebar.error("Column 'Underlying_Price' not found in Griegas.csv or file is empty. Cannot calculate GEX.")
+                st.error("GEX calculation requires 'Underlying_Price' in Griegas.csv.")
 
-
-            st.subheader("Gamma Exposure (GEX) & Potential Flip Points")
-            # GEX calculation needs Gamma, OI, Type, Strike.
-            # The 'Underlying_Price' from Griegas.csv (Price~) is used if per_share_gex=False in calc and plotting
-            total_gex, gex_by_strike, flip_points = calculations.calculate_gex_and_flip(
-                df_griegas,
-                underlying_price_col='Underlying_Price', # Make sure this column exists from file_handler
-                oi_col='Open Int',
-                gamma_col='Gamma',
-                type_col='Type',
-                strike_col='Strike'
-            )
-            if total_gex is not None and gex_by_strike is not None:
-                st.metric(label="Total Net GEX (approx. shares)", value=f"{total_gex:,.0f}")
-                fig_gex = plotting.plot_gex(gex_by_strike, total_gex, strike_col='Strike', gex_col='gex', flip_points_df=flip_points)
-                st.plotly_chart(fig_gex, use_container_width=True)
-                if flip_points is not None and not flip_points.empty:
-                    st.write("Potential Gamma Flip Strikes:", flip_points[['Strike', 'gex']])
+            if current_spot_price is not None:
+                st.subheader("Gamma Exposure (GEX) Analytics (Black-Scholes based)")
+                # Ensure all required columns for calculate_gex_analytics are present
+                required_gex_cols = ['Strike', 'Open Int', 'Type', 'IV']
+                # DTE or Exp Date is also checked inside calculate_gex_analytics
+                if not all(col in df_griegas.columns for col in required_gex_cols) or \
+                   ('Exp Date' not in df_griegas.columns and 'DTE' not in df_griegas.columns):
+                    st.error("Griegas.csv is missing one or more required columns for GEX: 'Strike', 'Open Int', 'Type', 'IV', and ('Exp Date' or 'DTE').")
                 else:
-                    st.write("No distinct gamma flip points identified based on current GEX profile.")
-            else:
-                st.info("Could not calculate GEX. Check 'Gamma', 'Open Int', 'Type', 'Strike' columns in Griegas.csv.")
+                    try:
+                        gex_bars, gex_curve, flip_price, net_gex_now = calculations.calculate_gex_analytics(
+                            df_griegas,
+                            current_spot_price=current_spot_price,
+                            risk_free_rate=risk_free_rate,
+                            calculation_date=calculation_date_ts # Use the pandas Timestamp
+                        )
+                        if gex_bars is not None and gex_curve is not None:
+                            st.metric(label="Net GEX at Current Price (approx. shares)", value=f"{net_gex_now:,.0f}")
+                            fig_gex_detailed = plotting.plot_gex_dashboard_view(
+                                gex_bars_data=gex_bars,
+                                df_aggregate_curve=gex_curve,
+                                gamma_flip_price=flip_price,
+                                net_gex_at_current_price=net_gex_now,
+                                current_spot_price=current_spot_price
+                            )
+                            st.plotly_chart(fig_gex_detailed, use_container_width=True)
+                            if flip_price is not None and not pd.isna(flip_price):
+                                st.metric(label="Calculated Gamma Flip Price", value=f"${flip_price:.2f}")
+                            else:
+                                st.info("Gamma Flip Price could not be determined (e.g., GEX curve does not cross zero or data insufficient).")
+                        else:
+                            st.warning("GEX Analytics could not be computed. Check data quality or console for errors from calculation module.")
+                    except Exception as e:
+                        st.error(f"Error during GEX calculation: {e}")
+                        st.exception(e)
+
 
             col_vega, col_theta = st.columns(2)
-            with col_vega:
-                st.subheader("Vega Exposure (Sensitivity to IV)")
-                total_vega, vega_by_strike = calculations.calculate_total_exposure(df_griegas, greek_col='Vega', oi_col='Open Int', type_col='Type', strike_col='Strike')
-                if total_vega is not None and vega_by_strike is not None:
-                    st.metric(label="Total Vega Exposure", value=f"${total_vega:,.0f}")
-                    fig_vega = plotting.plot_greek_exposure(vega_by_strike, total_vega, 'Vega', strike_col='Strike', exposure_col='exposure_value')
-                    st.plotly_chart(fig_vega, use_container_width=True)
-                else:
-                    st.info("Could not calculate Vega exposure. Check 'Vega' column.")
+            # Vega Exposure
+            if 'Vega' in df_griegas.columns:
+                with col_vega:
+                    st.subheader("Vega Exposure")
+                    total_vega, vega_by_strike = calculations.calculate_total_exposure(df_griegas, greek_col='Vega')
+                    if total_vega is not None and vega_by_strike is not None:
+                        st.metric(label="Total Vega Exposure", value=f"${total_vega:,.0f}")
+                        fig_vega = plotting.plot_greek_exposure(vega_by_strike, total_vega, 'Vega', strike_col='Strike')
+                        st.plotly_chart(fig_vega, use_container_width=True)
+                    else:
+                        st.info("Could not calculate Vega exposure.")
+            else:
+                 with col_vega:
+                    st.subheader("Vega Exposure")
+                    st.warning("Column 'Vega' not found in Griegas.csv.")
 
-            with col_theta:
-                st.subheader("Theta Exposure (Time Decay)")
-                total_theta, theta_by_strike = calculations.calculate_total_exposure(df_griegas, greek_col='Theta', oi_col='Open Int', type_col='Type', strike_col='Strike')
-                if total_theta is not None and theta_by_strike is not None:
-                    st.metric(label="Total Theta Exposure (Daily Decay)", value=f"${total_theta:,.0f}")
-                    fig_theta = plotting.plot_greek_exposure(theta_by_strike, total_theta, 'Theta', strike_col='Strike', exposure_col='exposure_value')
-                    st.plotly_chart(fig_theta, use_container_width=True)
-                else:
-                    st.info("Could not calculate Theta exposure. Check 'Theta' column.")
-        tab_idx += 1
+            # Theta Exposure
+            if 'Theta' in df_griegas.columns:
+                with col_theta:
+                    st.subheader("Theta Exposure")
+                    total_theta, theta_by_strike = calculations.calculate_total_exposure(df_griegas, greek_col='Theta')
+                    if total_theta is not None and theta_by_strike is not None:
+                        st.metric(label="Total Theta Exposure (Daily Decay)", value=f"${total_theta:,.0f}")
+                        fig_theta = plotting.plot_greek_exposure(theta_by_strike, total_theta, 'Theta', strike_col='Strike')
+                        st.plotly_chart(fig_theta, use_container_width=True)
+                    else:
+                        st.info("Could not calculate Theta exposure.")
+            else:
+                with col_theta:
+                    st.subheader("Theta Exposure")
+                    st.warning("Column 'Theta' not found in Griegas.csv.")
+        current_tab_idx += 1
 
-    # --- Tab 5: Unusual Option Flow (Requires Inusual.csv) ---
+    # --- Tab: Unusual Option Flow (Requires Inusual.csv) ---
     if df_inusual is not None:
-        with tabs[tab_idx]:
+        with tabs[current_tab_idx]:
             st.header("🌊 Unusual Option Flow (Inusual.csv)")
 
-            # Display a sample of the data
+            st.subheader("Raw Unusual Flow Data (Sample)")
             st.dataframe(df_inusual.head(), height=200)
 
-            # Plot unusual flow
-            # Ensure necessary columns like 'Symbol' (or provide a default in plotting if missing)
-            # 'Trade_Time' is used in hover, renamed from 'Time' in file_handler
-            fig_flow = plotting.plot_unusual_flow(
-                df_inusual,
-                strike_col='Strike',
-                premium_col='Trade', # 'Trade' column is the price of the option trade
-                size_col='Size',
-                side_col='Side',
-                type_col='Type',
-                time_col='Trade_Time', # Renamed in file_handler
-                symbol_col='Symbol' # Ensure this is present or handled in plotting
-            )
-            st.plotly_chart(fig_flow, use_container_width=True)
+            if not all(col in df_inusual.columns for col in ['Strike', 'Trade', 'Size', 'Side']):
+                st.warning("Missing one or more required columns for Unusual Flow plot: 'Strike', 'Trade', 'Size', 'Side'.")
+            else:
+                fig_flow = plotting.plot_unusual_flow(
+                    df_inusual,
+                    premium_col='Trade', # 'Trade' is the trade price per contract
+                )
+                st.plotly_chart(fig_flow, use_container_width=True)
 
-            st.subheader("Top Unusual Trades by Premium")
-            # Sort by 'Premium' (total dollar value of the trade)
-            if 'Premium' in df_inusual.columns:
+            st.subheader("Top Unusual Trades by Total Premium")
+            if 'Premium' in df_inusual.columns: # 'Premium' column is total dollar value of trade
                 top_trades = df_inusual.sort_values(by='Premium', ascending=False).head(10)
                 st.dataframe(top_trades)
+            elif 'Trade' in df_inusual.columns and 'Size' in df_inusual.columns:
+                 # Attempt to calculate total premium if 'Premium' column is missing
+                df_inusual['Calculated_Total_Premium'] = df_inusual['Trade'] * df_inusual['Size'] * 100 # Assuming 100 shares/contract
+                top_trades = df_inusual.sort_values(by='Calculated_Total_Premium', ascending=False).head(10)
+                st.dataframe(top_trades)
+                st.caption("Note: 'Premium' column (total value) was missing, calculated as Trade * Size * 100.")
             else:
-                st.info("Column 'Premium' (total value) not found for sorting top trades.")
-        tab_idx += 1
+                st.info("Column 'Premium' (total value) not found for sorting top trades, and cannot calculate it from 'Trade' and 'Size'.")
+        current_tab_idx += 1
 
 st.sidebar.markdown("---")
 st.sidebar.info("This dashboard provides an interactive analysis of options data. Calculations and interpretations are based on common financial models and may require domain expertise for full understanding.")
@@ -226,5 +255,5 @@ st.sidebar.info("This dashboard provides an interactive analysis of options data
 # To run this dashboard:
 # 1. Save this code as dashboard.py
 # 2. Ensure file_handler.py, calculations.py, plotting.py are in the same directory.
-# 3. Ensure requirements.txt lists streamlit, pandas, plotly. Install with `pip install -r requirements.txt`.
+# 3. Ensure requirements.txt lists streamlit, pandas, plotly, scipy. Install with `pip install -r requirements.txt`.
 # 4. Run `streamlit run dashboard.py` in your terminal.

--- a/plotting.py
+++ b/plotting.py
@@ -1,38 +1,60 @@
 import plotly.express as px
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import pandas as pd
+import numpy as np
 
 # Template for dark theme for plotly express figs
 THEME_DARK = "plotly_dark"
 
-def plot_volume_oi(df, strike_col='Strike', vol_col='Volume', oi_col='Open Int', type_col='Type', call_label='call', put_label='put'):
-    """Plots Volume and Open Interest by Strike for Calls and Puts."""
-    if df is None or df.empty:
-        return go.Figure()
+def plot_volume_by_strike(df, strike_col='Strike', vol_col='Volume', type_col='Type', call_label='call', put_label='put'):
+    """Plots Volume by Strike for Calls and Puts."""
+    if df is None or df.empty or not all(c in df.columns for c in [strike_col, vol_col, type_col]):
+        return go.Figure().update_layout(title_text='Volume by Strike (No Data or Missing Columns)', template=THEME_DARK)
 
     df_plot = df.copy()
     df_plot[type_col] = df_plot[type_col].str.lower()
 
     fig = go.Figure()
-
-    # Calls
-    df_calls = df_plot[df_plot[type_col] == call_label].sort_values(by=strike_col)
+    df_calls = df_plot[df_plot[type_col] == call_label].groupby(strike_col)[vol_col].sum().reset_index()
     fig.add_trace(go.Bar(x=df_calls[strike_col], y=df_calls[vol_col], name='Call Volume', marker_color='green'))
-    fig.add_trace(go.Bar(x=df_calls[strike_col], y=df_calls[oi_col], name='Call Open Interest', marker_color='lightgreen', visible='legendonly'))
 
-    # Puts
-    df_puts = df_plot[df_plot[type_col] == put_label].sort_values(by=strike_col)
+    df_puts = df_plot[df_plot[type_col] == put_label].groupby(strike_col)[vol_col].sum().reset_index()
     fig.add_trace(go.Bar(x=df_puts[strike_col], y=df_puts[vol_col], name='Put Volume', marker_color='red'))
-    fig.add_trace(go.Bar(x=df_puts[strike_col], y=df_puts[oi_col], name='Put Open Interest', marker_color='salmon', visible='legendonly'))
 
     fig.update_layout(
-        title_text='Volume and Open Interest by Strike',
+        title_text='Volume by Strike',
         xaxis_title='Strike Price',
-        yaxis_title='Amount',
+        yaxis_title='Volume',
         barmode='group',
         template=THEME_DARK
     )
     return fig
+
+def plot_oi_by_strike(df, strike_col='Strike', oi_col='Open Int', type_col='Type', call_label='call', put_label='put'):
+    """Plots Open Interest by Strike for Calls and Puts."""
+    if df is None or df.empty or not all(c in df.columns for c in [strike_col, oi_col, type_col]):
+        return go.Figure().update_layout(title_text='Open Interest by Strike (No Data or Missing Columns)', template=THEME_DARK)
+
+    df_plot = df.copy()
+    df_plot[type_col] = df_plot[type_col].str.lower()
+
+    fig = go.Figure()
+    df_calls = df_plot[df_plot[type_col] == call_label].groupby(strike_col)[oi_col].sum().reset_index()
+    fig.add_trace(go.Bar(x=df_calls[strike_col], y=df_calls[oi_col], name='Call Open Interest', marker_color='lightgreen'))
+
+    df_puts = df_plot[df_plot[type_col] == put_label].groupby(strike_col)[oi_col].sum().reset_index()
+    fig.add_trace(go.Bar(x=df_puts[strike_col], y=df_puts[oi_col], name='Put Open Interest', marker_color='salmon'))
+
+    fig.update_layout(
+        title_text='Open Interest by Strike',
+        xaxis_title='Strike Price',
+        yaxis_title='Open Interest',
+        barmode='group',
+        template=THEME_DARK
+    )
+    return fig
+
 
 def plot_put_call_ratio(pcr_data_by_strike, strike_col='Strike', pcr_col='pc_ratio', total_pcr=None):
     """Plots Put/Call Ratio by Strike and optionally displays total P/C Ratio."""
@@ -86,31 +108,68 @@ def plot_max_pain(max_pain_strike, cash_values_df, strike_price_col='strike_pric
         return go.Figure().update_layout(title_text='Max Pain Analysis (No Data)', template=THEME_DARK)
 
     fig = px.line(cash_values_df, x=strike_price_col, y=total_option_value_col,
-                  title=f'Max Pain Analysis - Minimized Option Value at: ${max_pain_strike}',
+                  title=f'Max Pain Analysis - Minimized Option Value at: ${max_pain_strike:.2f}',
                   labels={strike_price_col: 'Potential Expiry Price', total_option_value_col: 'Total Value of Options that would have Value'},
                   template=THEME_DARK)
     fig.add_vline(x=max_pain_strike, line_width=2, line_dash="dash", line_color="red",
-                  annotation_text=f"Max Pain: {max_pain_strike}", annotation_position="top right")
+                  annotation_text=f"Max Pain: {max_pain_strike:.2f}", annotation_position="top right")
     return fig
 
-def plot_gex(gex_by_strike_df, total_gex, strike_col='strike', gex_col='gex', flip_points_df=None):
-    """Plots Gamma Exposure (GEX) by strike and indicates total GEX and flip points."""
-    if gex_by_strike_df is None or gex_by_strike_df.empty:
-        fig = go.Figure().update_layout(title_text='Gamma Exposure (GEX) (No Data)', template=THEME_DARK)
-        if total_gex is not None:
-             fig.add_annotation(text=f"Total GEX: {total_gex:,.0f} shares (approx)", showarrow=False, xref="paper", yref="paper", x=0.5, y=0.9)
+def plot_gex_dashboard_view(gex_bars_data, df_aggregate_curve, gamma_flip_price,
+                            net_gex_at_current_price, current_spot_price):
+    """
+    Plots Gamma Exposure (GEX) by Strike (bars) and Aggregate GEX Curve (line).
+    Highlights current spot price and Gamma Flip Point.
+    """
+    if gex_bars_data is None or gex_bars_data.empty or df_aggregate_curve is None or df_aggregate_curve.empty:
+        fig = go.Figure().update_layout(title_text='Gamma Exposure (GEX) Analysis (No Data)', template=THEME_DARK)
+        if net_gex_at_current_price is not None:
+             fig.add_annotation(text=f"Net GEX at current price: {net_gex_at_current_price:,.0f}",
+                                showarrow=False, xref="paper", yref="paper", x=0.5, y=0.9)
         return fig
 
-    fig = px.bar(gex_by_strike_df, x=strike_col, y=gex_col, title=f'Gamma Exposure (GEX) by Strike (Total GEX: {total_gex:,.0f} shares approx.)',
-                 template=THEME_DARK)
-    fig.update_yaxes(title_text='GEX (Shares)')
-    fig.add_hline(y=0, line_width=1, line_dash="dash", line_color="grey")
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    if flip_points_df is not None and not flip_points_df.empty:
-        for idx, row in flip_points_df.iterrows():
-            fig.add_vline(x=row[strike_col], line_width=1, line_dash="longdash", line_color="yellow",
-                          annotation_text=f"Potential Flip: {row[strike_col]}", annotation_position="bottom right")
+    # Bar chart for GEX per strike
+    colors = ['green' if val >= 0 else 'red' for val in gex_bars_data['GEX_Signed_Value']]
+    fig.add_trace(
+        go.Bar(x=gex_bars_data['Strike'], y=gex_bars_data['GEX_Signed_Value'],
+               name='GEX per Strike', marker_color=colors),
+        secondary_y=False,
+    )
+
+    # Line chart for Aggregate GEX curve
+    fig.add_trace(
+        go.Scatter(x=df_aggregate_curve['Simulated_Price'], y=df_aggregate_curve['Total_GEX'],
+                   name='Aggregate GEX Curve', line=dict(color='deepskyblue', width=2)),
+        secondary_y=True, # Plotting on a secondary y-axis if scales differ significantly
+    )
+
+    # Line for current spot price
+    if current_spot_price is not None:
+        fig.add_vline(x=current_spot_price, line_width=2, line_dash="dash", line_color="yellow",
+                      annotation_text=f"Current Spot: {current_spot_price:.2f}",
+                      annotation_position="bottom right")
+
+    # Line for Gamma Flip Point
+    if gamma_flip_price is not None and not np.isnan(gamma_flip_price):
+        fig.add_vline(x=gamma_flip_price, line_width=2, line_dash="dot", line_color="magenta",
+                      annotation_text=f"Gamma Flip: {gamma_flip_price:.2f}",
+                      annotation_position="bottom left")
+
+    title_text = f'Gamma Exposure Analysis<br>Net GEX at Current Price: {net_gex_at_current_price:,.0f}'
+    fig.update_layout(
+        title_text=title_text,
+        xaxis_title='Underlying Price / Strike Price',
+        template=THEME_DARK,
+        legend_title_text='Legend',
+        barmode='relative' # Ensures bars are drawn from zero
+    )
+    fig.update_yaxes(title_text="GEX per Strike", secondary_y=False)
+    fig.update_yaxes(title_text="Total Aggregate GEX", secondary_y=True, showgrid=False) # Hide grid for secondary y-axis if desired
+
     return fig
+
 
 def plot_greek_exposure(exposure_df, total_exposure, greek_name, strike_col='strike', exposure_col='exposure_value'):
     """Plots total exposure for a given Greek (Vega, Theta) by strike."""
@@ -119,7 +178,7 @@ def plot_greek_exposure(exposure_df, total_exposure, greek_name, strike_col='str
 
     title = f'Total {greek_name} Exposure by Strike (Overall: {total_exposure:,.2f})'
     fig = px.bar(exposure_df, x=strike_col, y=exposure_col, title=title, template=THEME_DARK)
-    fig.update_yaxes(title_text=f'{greek_name} Exposure')
+    fig.update_yaxes(title_text=f'{greek_name} Exposure ($)') # Assuming exposure is in $
     return fig
 
 def plot_unusual_flow(df_inusual, strike_col='Strike', premium_col='Premium', size_col='Size',
@@ -128,21 +187,17 @@ def plot_unusual_flow(df_inusual, strike_col='Strike', premium_col='Premium', si
     if df_inusual is None or df_inusual.empty:
         return go.Figure().update_layout(title_text='Unusual Option Flow (No Data)', template=THEME_DARK)
 
-    # Ensure required columns exist, or provide defaults
     df_plot = df_inusual.copy()
-    if symbol_col not in df_plot.columns and 'Symbol' in df_plot.columns: # Check if 'Symbol' was not passed as symbol_col
-        df_plot[symbol_col] = df_plot['Symbol'] # Use default if available
+    if symbol_col not in df_plot.columns and 'Symbol' in df_plot.columns:
+        df_plot[symbol_col] = df_plot['Symbol']
     elif symbol_col not in df_plot.columns:
          df_plot[symbol_col] = "N/A"
 
-
     hover_data = [strike_col, premium_col, size_col, side_col, type_col, time_col, symbol_col]
-    # Filter out columns not present in df_plot for hover_data
     hover_data = [col for col in hover_data if col in df_plot.columns]
 
-
-    fig = px.scatter(df_plot, x=strike_col, y=premium_col,
-                     size=size_col, color=side_col, # Or type_col
+    fig = px.scatter(df_plot, x=strike_col, y=premium_col, # 'premium_col' here is trade price
+                     size=size_col, color=side_col,
                      hover_name=symbol_col if symbol_col in df_plot.columns else None,
                      hover_data=hover_data,
                      title='Unusual Option Flow Activity',
@@ -151,7 +206,7 @@ def plot_unusual_flow(df_inusual, strike_col='Strike', premium_col='Premium', si
 
     fig.update_layout(
         xaxis_title='Strike Price',
-        yaxis_title='Premium Paid/Received per Contract (Trade Price)',
+        yaxis_title='Trade Price per Contract', # Changed from 'Premium' to 'Trade Price'
         coloraxis_colorbar=dict(title="Trade Side")
     )
     return fig
@@ -161,69 +216,40 @@ if __name__ == '__main__':
     # Create dummy data for testing plots
     sample_strikes = list(range(50, 75, 5))
 
-    # For plot_volume_oi
-    df_vol_oi_sample = pd.DataFrame({
+    # For plot_volume_by_strike and plot_oi_by_strike
+    df_chain_sample = pd.DataFrame({
         'Strike': sample_strikes * 2,
         'Volume': [100, 200, 500, 300, 50] * 2,
         'Open Int': [1000, 1500, 3000, 2000, 500] * 2,
         'Type': ['call']*len(sample_strikes) + ['put']*len(sample_strikes)
     })
-    fig_vol_oi = plot_volume_oi(df_vol_oi_sample)
-    # fig_vol_oi.show() # Uncomment to display locally if running this file
+    fig_vol = plot_volume_by_strike(df_chain_sample)
+    # fig_vol.show()
+    fig_oi = plot_oi_by_strike(df_chain_sample)
+    # fig_oi.show()
 
-    # For plot_put_call_ratio
-    pcr_data_sample = pd.DataFrame({
+    # For plot_gex_dashboard_view
+    gex_bars_sample = pd.DataFrame({
         'Strike': sample_strikes,
-        'pc_ratio': [0.5, 0.8, 1.0, 1.2, 0.9]
+        'GEX_Signed_Value': [-100000, 50000, 200000, -80000, 30000]
     })
-    fig_pcr = plot_put_call_ratio(pcr_data_sample, total_pcr=0.95)
-    # fig_pcr.show()
-
-    # For plot_money_at_risk
-    mar_sample = pd.DataFrame({
-        'Strike': sample_strikes,
-        'call_money_at_risk': [100000, 150000, 200000, 120000, 40000],
-        'put_money_at_risk': [80000, 130000, 180000, 100000, 30000]
+    aggregate_curve_sample = pd.DataFrame({
+        'Simulated_Price': np.linspace(min(sample_strikes)*0.9, max(sample_strikes)*1.1, 50),
+        'Total_GEX': np.sin(np.linspace(0, 2*np.pi, 50)) * 500000
     })
-    fig_mar = plot_money_at_risk(mar_sample)
-    # fig_mar.show()
+    aggregate_curve_sample.loc[aggregate_curve_sample['Simulated_Price'] < 60, 'Total_GEX'] *= -1 # Make some negative for flip
 
-    # For plot_max_pain
-    max_pain_df_sample = pd.DataFrame({
-        'strike_price_at_expiry': sample_strikes,
-        'total_option_value': [500000, 400000, 350000, 420000, 520000]
-    })
-    fig_max_pain = plot_max_pain(max_pain_strike=60, cash_values_df=max_pain_df_sample)
-    # fig_max_pain.show()
+    flip_price_sample = 58.0
+    net_gex_current_sample = 100000
+    current_spot_sample = 62.5
 
-    # For plot_gex
-    gex_sample_df = pd.DataFrame({
-        'strike': sample_strikes,
-        'gex': [-10000, -5000, 2000, 8000, 3000] # Shares
-    })
-    flip_sample_df = pd.DataFrame({'strike': [57.5], 'gex': [0]}) # Dummy flip point
-    fig_gex = plot_gex(gex_sample_df, total_gex=sum(gex_sample_df['gex']), flip_points_df=flip_sample_df)
-    # fig_gex.show()
+    fig_gex_detailed = plot_gex_dashboard_view(
+        gex_bars_sample,
+        aggregate_curve_sample,
+        flip_price_sample,
+        net_gex_current_sample,
+        current_spot_sample
+    )
+    # fig_gex_detailed.show()
 
-    # For plot_greek_exposure (Vega)
-    vega_exposure_sample = pd.DataFrame({
-        'strike': sample_strikes,
-        'exposure_value': [5000, 8000, 12000, 7000, 2000]
-    })
-    fig_vega = plot_greek_exposure(vega_exposure_sample, total_exposure=sum(vega_exposure_sample['exposure_value']), greek_name='Vega')
-    # fig_vega.show()
-
-    # For plot_unusual_flow
-    inusual_flow_sample = pd.DataFrame({
-        'Symbol': ['XYZ'] * 5,
-        'Strike': sample_strikes,
-        'Premium': [1.5, 2.0, 2.5, 1.0, 0.5], # Trade price
-        'Size': [100, 50, 200, 150, 75], # Number of contracts
-        'Side': ['buy', 'buy', 'sell', 'buy', 'sell'],
-        'Type': ['call', 'call', 'put', 'call', 'put'],
-        'Trade_Time': ['10:00', '10:05', '10:15', '10:20', '10:30']
-    })
-    fig_flow = plot_unusual_flow(inusual_flow_sample)
-    # fig_flow.show()
-
-    print("Plotting functions created with dummy examples. Uncomment '.show()' lines to display plots if running locally.")
+    print("Plotting functions updated/created with dummy examples. Uncomment '.show()' lines to display plots if running locally.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 plotly
 numpy
+scipy


### PR DESCRIPTION
- Updated `calculations.py` to implement a detailed Gamma Exposure (GEX) calculation based on Black-Scholes model as per user specification.
  - Added `calculate_black_scholes_gamma` helper function.
  - New `calculate_gex_analytics` function computes:
    - Gamma per option contract using B-S.
    - GEX per strike (signed: Call+, Put-) for bar chart.
    - Simulated aggregate GEX curve by recalculating total GEX over a range of spot prices.
    - Gamma Flip Point based on the aggregate curve crossing zero.
- Updated `plotting.py`:
  - Added `plot_gex_dashboard_view` to visualize the new GEX bar data, aggregate curve, current price, and flip point.
  - Added `plot_volume_by_strike` and `plot_oi_by_strike` for separate Volume and Open Interest charts, replacing the combined one.
- Updated `dashboard.py`:
  - Added sidebar inputs for risk-free rate and calculation date.
  - Integrated new GEX calculation and plotting functions into the 'Greek Exposures' tab.
  - Updated 'Chain Overview & Sentiment' tab to use the new separate Volume and OI plots.
- Added `scipy` to `requirements.txt` for `scipy.stats.norm` used in Black-Scholes gamma calculation.