### PR TITLE
Fix: Handle scalar Spot price in Black-Scholes Gamma

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -6,178 +6,194 @@ import datetime # Required for date calculations if DTE is not directly availabl
 def calculate_black_scholes_gamma(S, K, T, r, sigma):
     """
     Calculates the Black-Scholes Gamma for an option.
-    S: Current price of the underlying asset
-    K: Strike price of the option
-    T: Time to expiration (in years)
-    r: Risk-free interest rate (annualized)
-    sigma: Volatility of the underlying asset (annualized)
+    S: Current price of the underlying asset (can be scalar or array)
+    K: Strike price of the option (array)
+    T: Time to expiration (in years) (array)
+    r: Risk-free interest rate (annualized) (scalar or array)
+    sigma: Volatility of the underlying asset (annualized) (array)
     """
-    # Ensure inputs are array-like for vectorized operations
-    S = np.asarray(S)
-    K = np.asarray(K)
-    T = np.asarray(T)
-    r = np.asarray(r)
-    sigma = np.asarray(sigma)
+    _S = np.asarray(S)
+    _K = np.asarray(K)
+    _T = np.asarray(T)
+    _r = np.asarray(r)
+    _sigma = np.asarray(sigma)
 
-    # Initialize gamma array with NaNs or zeros
-    gamma = np.full_like(S, np.nan, dtype=np.double)
+    # Initialize gamma array with NaNs, matching shape of K
+    gamma_output = np.full_like(_K, np.nan, dtype=np.float64)
 
-    # Avoid calculations for invalid inputs (T=0, sigma=0, S=0)
-    valid_mask = (T > 1e-6) & (sigma > 1e-6) & (S > 1e-6) # Use a small epsilon for T, sigma, S > 0
+    # Create a mask for valid calculations based on array inputs K, T, sigma
+    # and scalar/array S, r
+    # S must be > 0. If S is an array, this check is element-wise.
+    # If S is scalar, it's a single check.
+    s_is_scalar = _S.ndim == 0
 
-    if np.any(valid_mask):
-        S_valid = S[valid_mask]
-        K_valid = K[valid_mask]
-        T_valid = T[valid_mask]
-        r_valid = r[valid_mask] if np.isscalar(r) else r[valid_mask] # handle scalar r
-        sigma_valid = sigma[valid_mask] if np.isscalar(sigma) else sigma[valid_mask] # handle scalar sigma
+    if s_is_scalar:
+        if _S <= 1e-9: # If scalar S is invalid, all gammas are NaN (or could be 0)
+            return gamma_output
+        # Create a boolean array for S matching K's shape for the mask
+        s_condition = np.full_like(_K, True, dtype=bool) # Placeholder, S is valid
+    else:
+        s_condition = (_S > 1e-9)
 
-        d1_numerator = np.log(S_valid / K_valid) + (r_valid + 0.5 * sigma_valid**2) * T_valid
-        d1_denominator = sigma_valid * np.sqrt(T_valid)
+    # Mask for options that are valid for calculation (T>0, sigma>0, K>0 and S>0)
+    # This mask will have the same shape as K, T, sigma
+    valid_mask = (_T > 1e-9) & (_sigma > 1e-9) & (_K > 1e-9) & s_condition
 
-        # Avoid division by zero in d1_denominator
-        d1 = np.full_like(S_valid, np.nan, dtype=np.double)
-        denom_valid_mask = (d1_denominator > 1e-9) # Check denominator is not too small
+    if not np.any(valid_mask):
+        return gamma_output # No valid options to calculate
 
-        d1[denom_valid_mask] = d1_numerator[denom_valid_mask] / d1_denominator[denom_valid_mask]
-        d1[~denom_valid_mask] = np.inf * np.sign(d1_numerator[~denom_valid_mask]) # Handle case for very small sigma*sqrt(T)
+    # Select only valid rows for calculation to avoid warnings/errors
+    # If S or r are scalars, they will broadcast correctly.
+    # If S or r are arrays, they must be filtered by valid_mask as well.
+    S_eff = _S if s_is_scalar else _S[valid_mask]
+    K_eff = _K[valid_mask]
+    T_eff = _T[valid_mask]
+    r_eff = _r if np.isscalar(_r) else (_r[valid_mask] if _r.ndim > 0 else _r) # Handle scalar r or array r
+    sigma_eff = _sigma[valid_mask]
 
-        phi_d1 = norm.pdf(d1)
+    # d1 calculation
+    d1_numerator = np.log(S_eff / K_eff) + (r_eff + 0.5 * sigma_eff**2) * T_eff
+    d1_denominator = sigma_eff * np.sqrt(T_eff)
 
-        gamma_denominator = S_valid * sigma_valid * np.sqrt(T_valid)
-        gamma_calc = np.full_like(S_valid, np.nan, dtype=np.double)
+    # Avoid division by zero in d1_denominator
+    # np.divide handles division by zero by returning inf or nan, which is fine for norm.pdf
+    d1 = np.divide(d1_numerator, d1_denominator, out=np.full_like(d1_denominator, np.nan), where=d1_denominator!=0)
 
-        gamma_denom_valid_mask = (gamma_denominator > 1e-9)
-        gamma_calc[gamma_denom_valid_mask] = phi_d1[gamma_denom_valid_mask] / gamma_denominator[gamma_denom_valid_mask]
+    phi_d1 = norm.pdf(d1)
 
-        gamma[valid_mask] = gamma_calc
+    # Gamma calculation
+    gamma_denominator = S_eff * sigma_eff * np.sqrt(T_eff)
 
-    return gamma
+    # Calculate gamma for the valid subset
+    calculated_gamma_subset = np.divide(phi_d1, gamma_denominator, out=np.full_like(gamma_denominator, np.nan), where=gamma_denominator!=0)
+
+    # Place the calculated gammas back into the original shaped array
+    gamma_output[valid_mask] = calculated_gamma_subset
+
+    return gamma_output
+
 
 def calculate_gex_analytics(df_options_original, current_spot_price, risk_free_rate, calculation_date=None):
     """
     Calculates Gamma Exposure by Strike, Aggregate Gamma Exposure Curve, and Gamma Flip Point.
     """
     if df_options_original is None or df_options_original.empty:
-        return None, None, np.nan, np.nan
+        return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
 
-    if not all(col in df_options_original.columns for col in ['Strike', 'Open Int', 'Type', 'IV']):
-        print("Missing one or more required columns: 'Strike', 'Open Int', 'Type', 'IV'")
-        return None, None, np.nan, np.nan
+    required_cols = ['Strike', 'Open Int', 'Type', 'IV']
+    if not all(col in df_options_original.columns for col in required_cols):
+        print(f"GEX Error: Missing one or more required columns: {required_cols}")
+        return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
+
     if 'Exp Date' not in df_options_original.columns and 'DTE' not in df_options_original.columns:
-        print("Missing 'Exp Date' or 'DTE' column for time to maturity calculation.")
-        return None, None, np.nan, np.nan
+        print("GEX Error: Missing 'Exp Date' or 'DTE' column for time to maturity calculation.")
+        return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
 
     df = df_options_original.copy()
-
-    # Ensure 'Type' is lowercase
     df['Type'] = df['Type'].str.lower()
 
-    # Part A: Calculate Gamma for each contract using current_spot_price
     if calculation_date is None:
         calculation_date = pd.Timestamp('today').normalize()
     else:
         calculation_date = pd.to_datetime(calculation_date).normalize()
 
     if 'DTE' not in df.columns:
-        if 'Exp Date' not in df.columns:
-             raise ValueError("DataFrame must have either 'DTE' or 'Exp Date' column.")
         df['Exp Date'] = pd.to_datetime(df['Exp Date'])
         df['DTE'] = (df['Exp Date'] - calculation_date).dt.days
 
     df['T_years'] = df['DTE'] / 365.25
 
-    # Filter out expired or invalid options for Gamma calculation
-    valid_options_for_gamma = df[df['T_years'] > 1e-6].copy() # Small epsilon to avoid T=0 issues
-    if valid_options_for_gamma.empty:
-        print("No valid options with T_years > 0 for Gamma calculation.")
+    # Filter for options with T_years > 0 (and other conditions handled in calculate_black_scholes_gamma)
+    # Ensure IV is numeric and positive
+    df['IV'] = pd.to_numeric(df['IV'], errors='coerce')
+    df = df[(df['T_years'] > 1e-6) & (df['IV'] > 1e-6) & (df['Strike'] > 1e-6) & (df['Open Int'] >= 0)]
+
+    if df.empty:
+        print("GEX Warning: No valid options after filtering for T_years > 0, IV > 0, Strike > 0.")
         return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
 
-    valid_options_for_gamma['Calculated_Gamma'] = calculate_black_scholes_gamma(
+    # Part A: Calculate Gamma for each contract using current_spot_price
+    df['Calculated_Gamma'] = calculate_black_scholes_gamma(
         S=current_spot_price,
-        K=valid_options_for_gamma['Strike'],
-        T=valid_options_for_gamma['T_years'],
+        K=df['Strike'].values, # Pass as numpy array
+        T=df['T_years'].values,
         r=risk_free_rate,
-        sigma=valid_options_for_gamma['IV'] # Assumes IV is already in decimal form
+        sigma=df['IV'].values
     )
-    valid_options_for_gamma.dropna(subset=['Calculated_Gamma'], inplace=True) # Remove rows where gamma calc failed
+    # Drop rows where gamma calculation failed (e.g., due to T=0 or other invalid BS params)
+    df.dropna(subset=['Calculated_Gamma'], inplace=True)
+    if df.empty:
+        print("GEX Warning: No options with valid Calculated_Gamma at current spot price.")
+        return pd.DataFrame(columns=['Strike', 'GEX_Signed_Value']), pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, 0
 
     # Part B: Calculate Gamma Exposure by Strike (for the bars)
-    valid_options_for_gamma['GEX_Contract_Value'] = valid_options_for_gamma['Calculated_Gamma'] * valid_options_for_gamma['Open Int'] * 100
-    valid_options_for_gamma['GEX_Signed_Value'] = np.where(
-        valid_options_for_gamma['Type'] == 'call',
-        valid_options_for_gamma['GEX_Contract_Value'],
-        -valid_options_for_gamma['GEX_Contract_Value']
+    df['GEX_Contract_Value'] = df['Calculated_Gamma'] * df['Open Int'] * 100
+    df['GEX_Signed_Value'] = np.where(
+        df['Type'] == 'call',
+        df['GEX_Contract_Value'],
+        -df['GEX_Contract_Value']
     )
 
-    if valid_options_for_gamma.empty: # Check again after gamma calculation and signing
-        gex_bars_data = pd.DataFrame({'Strike': [], 'GEX_Signed_Value': []})
-        net_gex_at_current_price = 0
-    else:
-        gex_bars_data = valid_options_for_gamma.groupby('Strike')['GEX_Signed_Value'].sum().reset_index()
-        net_gex_at_current_price = gex_bars_data['GEX_Signed_Value'].sum()
+    gex_bars_data = df.groupby('Strike')['GEX_Signed_Value'].sum().reset_index()
+    net_gex_at_current_price = np.nansum(gex_bars_data['GEX_Signed_Value'])
 
 
     # Part C: Calculate Aggregate Gamma Exposure Curve and Flip Point
-    # Use all options from the original valid_options_for_gamma for simulation, as T_years remains constant for this part
-    # We need df_copy of valid_options_for_gamma to ensure T_years and other necessary columns are present
-    sim_df = valid_options_for_gamma.copy()
-
-    min_price = current_spot_price * 0.80
-    max_price = current_spot_price * 1.20
-    # Ensure step is reasonable, avoid too many points if price range is huge, or too few if small
-    price_step = max(0.1, round((max_price - min_price) / 100, 2)) # Aim for around 100-200 points
-    if price_step == 0: price_step = 0.5 # Default if range is tiny
-
-    test_price_range = np.arange(min_price, max_price + price_step, price_step) # + price_step to include upper bound
+    min_price_sim = current_spot_price * 0.80
+    max_price_sim = current_spot_price * 1.20
+    price_step_sim = max(0.1, round((max_price_sim - min_price_sim) / 100, 2)) # Aim for ~100 points
+    if price_step_sim == 0: price_step_sim = 0.5
+    test_price_range = np.arange(min_price_sim, max_price_sim + price_step_sim, price_step_sim)
 
     simulated_gex_totals = []
 
+    # Prepare arrays from the DataFrame for faster processing in the loop
+    # These are from the already filtered 'df' which has valid T_years, IV etc.
+    strikes_arr = df['Strike'].values
+    t_years_arr = df['T_years'].values
+    iv_arr = df['IV'].values
+    oi_arr = df['Open Int'].values
+    type_is_call_arr = (df['Type'] == 'call').values
+
     for s_sim in test_price_range:
-        # Recalculate gamma for all options at this s_sim
-        gamma_sim = calculate_black_scholes_gamma(
-            S=s_sim,
-            K=sim_df['Strike'],
-            T=sim_df['T_years'],
-            r=risk_free_rate,
-            sigma=sim_df['IV']
+        gamma_sim_all = calculate_black_scholes_gamma(
+            S=s_sim, K=strikes_arr, T=t_years_arr, r=risk_free_rate, sigma=iv_arr
         )
 
-        gex_contract_sim = gamma_sim * sim_df['Open Int'] * 100
-        gex_signed_sim = np.where(sim_df['Type'] == 'call', gex_contract_sim, -gex_contract_sim)
-        total_gex_for_s_sim = np.nansum(gex_signed_sim) # Use nansum in case any gamma_sim was NaN
+        gex_contract_sim = gamma_sim_all * oi_arr * 100
+        # Ensure gex_signed_sim is calculated correctly, handling NaNs from gamma_sim if any
+        gex_signed_sim = np.where(type_is_call_arr, gex_contract_sim, -gex_contract_sim)
+        total_gex_for_s_sim = np.nansum(gex_signed_sim)
 
         simulated_gex_totals.append({'Simulated_Price': s_sim, 'Total_GEX': total_gex_for_s_sim})
 
     df_aggregate_curve = pd.DataFrame(simulated_gex_totals)
-    df_aggregate_curve.sort_values(by='Simulated_Price', inplace=True) # Ensure it's sorted for flip point logic
+    if df_aggregate_curve.empty: # Should not happen if test_price_range is not empty
+        return gex_bars_data, pd.DataFrame(columns=['Simulated_Price', 'Total_GEX']), np.nan, net_gex_at_current_price
+
+    df_aggregate_curve.sort_values(by='Simulated_Price', inplace=True)
 
     # Find Gamma Flip Point
     gamma_flip_price = np.nan
-    prev_gex = None
-    prev_price = None
-    for index, row in df_aggregate_curve.iterrows():
-        current_gex = row['Total_GEX']
-        current_price = row['Simulated_Price']
-        if prev_gex is not None:
-            if prev_gex < 0 and current_gex >= 0:
-                # Linear interpolation for a more precise flip point
-                if (current_gex - prev_gex) != 0: # Avoid division by zero
-                    gamma_flip_price = prev_price - prev_gex * (current_price - prev_price) / (current_gex - prev_gex)
-                else:
-                    gamma_flip_price = (prev_price + current_price) / 2 # Fallback to midpoint
-                break
-        prev_gex = current_gex
-        prev_price = current_price
+    # Shift Total_GEX to compare previous with current
+    gex_values = df_aggregate_curve['Total_GEX'].values
+    prices = df_aggregate_curve['Simulated_Price'].values
+
+    for i in range(1, len(gex_values)):
+        if gex_values[i-1] < 0 and gex_values[i] >= 0:
+            # Linear interpolation for a more precise flip point
+            gex1, gex2 = gex_values[i-1], gex_values[i]
+            p1, p2 = prices[i-1], prices[i]
+            if (gex2 - gex1) != 0: # Avoid division by zero if GEX values are identical
+                gamma_flip_price = p1 - gex1 * (p2 - p1) / (gex2 - gex1)
+            else: # GEX values are the same (likely both zero or very close)
+                gamma_flip_price = (p1 + p2) / 2
+            break
 
     return gex_bars_data, df_aggregate_curve, gamma_flip_price, net_gex_at_current_price
 
 
 def calculate_put_call_ratio(df, value_col, type_col='Type', strike_col='Strike', call_label='call', put_label='put'):
-    """
-    Calculates Put/Call Ratio based on a specified value column (e.g., Volume or Open Interest).
-    Can return total P/C ratio and P/C ratio per strike.
-    """
     if df is None or df.empty:
         return None, None
 
@@ -216,42 +232,45 @@ def calculate_money_at_risk(df, oi_col='Open Int', mid_price_col='Mid', type_col
 
 def calculate_max_pain(df_cadena, strike_col='Strike', oi_col='Open Int', type_col='Type', call_label='call', put_label='put', multiplier=100):
     if df_cadena is None or df_cadena.empty or not all(col in df_cadena.columns for col in [strike_col, oi_col, type_col]):
-        return None
+        return None, None # Return None for both if initial check fails
 
-    unique_strikes = sorted(df_cadena[strike_col].unique())
+    unique_strikes = sorted(df_cadena[strike_col].astype(float).unique()) # Ensure strikes are float for comparison
     if not unique_strikes:
-        return None, None
+        return None, None # No strikes to process
 
     cash_values_at_expiry = []
 
     for expiry_price in unique_strikes:
         total_value_if_expired_at_strike = 0
 
-        calls = df_cadena[df_cadena[type_col].str.lower() == call_label]
-        intrinsic_value_calls = np.maximum(0, expiry_price - calls[strike_col]) * calls[oi_col] * multiplier
+        # Calls: intrinsic value = max(0, S - K) * OI * multiplier
+        calls_df = df_cadena[df_cadena[type_col].str.lower() == call_label]
+        intrinsic_value_calls = np.maximum(0, expiry_price - calls_df[strike_col]) * calls_df[oi_col] * multiplier
         total_value_if_expired_at_strike += intrinsic_value_calls.sum()
 
-        puts = df_cadena[df_cadena[type_col].str.lower() == put_label]
-        intrinsic_value_puts = np.maximum(0, puts[strike_col] - expiry_price) * puts[oi_col] * multiplier
+        # Puts: intrinsic value = max(0, K - S) * OI * multiplier
+        puts_df = df_cadena[df_cadena[type_col].str.lower() == put_label]
+        intrinsic_value_puts = np.maximum(0, puts_df[strike_col] - expiry_price) * puts_df[oi_col] * multiplier
         total_value_if_expired_at_strike += intrinsic_value_puts.sum()
 
         cash_values_at_expiry.append({'strike_price_at_expiry': expiry_price, 'total_option_value': total_value_if_expired_at_strike})
 
     if not cash_values_at_expiry:
-        return None, None
+        return None, None # Should not happen if unique_strikes is not empty
 
     cash_values_df = pd.DataFrame(cash_values_at_expiry)
+    if cash_values_df.empty:
+        return None, None
+
     max_pain_strike_info = cash_values_df.loc[cash_values_df['total_option_value'].idxmin()]
     max_pain_strike = max_pain_strike_info['strike_price_at_expiry']
 
     return max_pain_strike, cash_values_df
 
 
-# This function is now superseded by calculate_gex_analytics
-# def calculate_gex_and_flip(df_griegas, underlying_price_col='Underlying_Price', oi_col='Open Int',
-#                            gamma_col='Gamma', type_col='Type', strike_col='Strike',
-#                            call_label='call', put_label='put', per_share_gex=False):
-#     pass # Obsolete
+# Obsolete GEX function
+# def calculate_gex_and_flip(...):
+#     pass
 
 
 def calculate_total_exposure(df_griegas, greek_col, oi_col='Open Int', type_col='Type', strike_col='Strike', multiplier=100):
@@ -259,11 +278,10 @@ def calculate_total_exposure(df_griegas, greek_col, oi_col='Open Int', type_col=
         return None, None
 
     df = df_griegas.copy()
-    # Ensure the greek column is numeric, coercing errors. This is important if Gamma is pre-calculated and might have NaNs.
     df[greek_col] = pd.to_numeric(df[greek_col], errors='coerce')
-    df.dropna(subset=[greek_col, oi_col], inplace=True) # Drop rows where essential data for calculation is missing
+    df.dropna(subset=[greek_col, oi_col], inplace=True)
 
-    if df.empty: # Check if df became empty after dropping NaNs
+    if df.empty:
         return None, None
 
     df['exposure_value'] = df[greek_col] * df[oi_col] * multiplier
@@ -276,41 +294,32 @@ def calculate_total_exposure(df_griegas, greek_col, oi_col='Open Int', type_col=
 
 # Example Usage (for testing, normally called from dashboard.py)
 if __name__ == '__main__':
-    # Sample DataFrames
     cadena_dict = {
-        'Strike': [50, 55, 60, 65, 70, 50, 55, 60, 65, 70],
+        'Strike': np.array([50, 55, 60, 65, 70, 50, 55, 60, 65, 70],dtype=float),
         'Mid': [10.5, 6.0, 2.5, 0.8, 0.2, 0.3, 0.7, 2.0, 5.5, 9.8],
         'Volume': [100, 200, 500, 300, 50, 80, 150, 400, 250, 60],
         'Open Int': [1000, 1500, 3000, 2000, 500, 800, 1200, 2500, 1800, 600],
         'Type': ['call', 'call', 'call', 'call', 'call', 'put', 'put', 'put', 'put', 'put'],
         'IV': [0.3, 0.28, 0.25, 0.27, 0.32, 0.31, 0.29, 0.26, 0.28, 0.33],
-        'Exp Date': ['2025-12-31']*10 # Example Expiry
+        'Exp Date': pd.to_datetime(['2025-12-31']*10)
     }
     df_cadena_sample = pd.DataFrame(cadena_dict)
-    df_cadena_sample['Exp Date'] = pd.to_datetime(df_cadena_sample['Exp Date'])
 
+    today_for_calc = pd.Timestamp('2024-07-26') # Fixed date for consistent DTE in test
 
-    # Test for calculate_gex_analytics
     print("\n--- GEX Analytics (New Detailed Calculation) ---")
-    # Assuming 'Underlying_Price' would be part of a df_griegas or passed directly
-    # For this test, let's use a structure similar to what df_griegas might provide
-    # We need 'Strike', 'Open Int', 'Type', 'IV', and 'Exp Date' (or 'DTE')
-
-    # Let's use df_cadena_sample as the base for df_griegas_sample for GEX
     df_griegas_for_gex = df_cadena_sample[['Strike', 'Open Int', 'Type', 'IV', 'Exp Date']].copy()
+    # Calculate DTE for the sample data based on fixed 'today_for_calc'
+    df_griegas_for_gex['DTE'] = (df_griegas_for_gex['Exp Date'] - today_for_calc).dt.days
+
     current_s = 60.0
     risk_free_r = 0.05
-    today = pd.Timestamp('today').normalize()
-
-    # Ensure DTE is calculated for the sample data if not present
-    if 'DTE' not in df_griegas_for_gex.columns:
-        df_griegas_for_gex['DTE'] = (df_griegas_for_gex['Exp Date'] - today).dt.days
 
     gex_bars, gex_curve, flip_price, net_gex_now = calculate_gex_analytics(
         df_griegas_for_gex,
         current_spot_price=current_s,
         risk_free_rate=risk_free_r,
-        calculation_date=today
+        calculation_date=today_for_calc
     )
 
     if gex_bars is not None:
@@ -319,13 +328,14 @@ if __name__ == '__main__':
     if gex_curve is not None:
         print("\nAggregate GEX Curve Data (Simulated Prices):")
         print(gex_curve.head())
+        print(gex_curve.tail())
     print(f"\nGamma Flip Price: {flip_price}")
-    print(f"Net GEX at Current Price ({current_s}): {net_gex_now}")
+    print(f"Net GEX at Current Price ({current_s}): {net_gex_now:,.0f}")
 
 
     print("\n--- Put/Call Ratio (Volume) ---")
     total_pc_vol, pc_vol_strike = calculate_put_call_ratio(df_cadena_sample, value_col='Volume')
-    print(f"Total P/C Ratio (Volume): {total_pc_vol}")
+    print(f"Total P/C Ratio (Volume): {total_pc_vol:.2f}")
     if pc_vol_strike is not None: print(pc_vol_strike.head())
 
     print("\n--- Money at Risk ---")
@@ -333,27 +343,19 @@ if __name__ == '__main__':
     if mar_df is not None: print(mar_df.head())
 
     print("\n--- Max Pain ---")
-    max_pain_strike, max_pain_df_viz = calculate_max_pain(df_cadena_sample) # Renamed to avoid conflict
-    print(f"Max Pain Strike: {max_pain_strike}")
+    max_pain_strike, max_pain_df_viz = calculate_max_pain(df_cadena_sample)
+    if max_pain_strike is not None:
+        print(f"Max Pain Strike: {max_pain_strike:.2f}")
     if max_pain_df_viz is not None: print(max_pain_df_viz.head())
 
-    # For Total Exposure, we need a 'Gamma' column if not calculating it via BS
-    # Let's assume df_griegas_for_gex now has 'Calculated_Gamma' from the GEX test
-    # For testing calculate_total_exposure, we can reuse the structure.
-    # If df_griegas_for_gex was modified in-place by calculate_gex_analytics with 'Calculated_Gamma',
-    # we might need to be careful or re-fetch/re-create.
-    # The current calculate_gex_analytics makes a copy, so df_griegas_for_gex is unchanged.
-    # For testing total_exposure for vega/theta, let's add dummy Vega/Theta to df_griegas_for_gex
-    df_griegas_for_gex['Vega'] = [0.2, 0.3, 0.4, 0.25, 0.1, 0.18, 0.28, 0.38, 0.23, 0.08] # Example Vega
-    df_griegas_for_gex['Theta'] = [-0.05, -0.08, -0.10, -0.06, -0.02, -0.04, -0.07, -0.09, -0.05, -0.01] # Example Theta
-
+    df_griegas_for_gex['Vega'] = [0.2, 0.3, 0.4, 0.25, 0.1, 0.18, 0.28, 0.38, 0.23, 0.08]
+    df_griegas_for_gex['Theta'] = [-0.05, -0.08, -0.10, -0.06, -0.02, -0.04, -0.07, -0.09, -0.05, -0.01]
 
     print("\n--- Total Vega Exposure ---")
-    # Ensure the greek_col passed exists in the dataframe.
     if 'Vega' in df_griegas_for_gex.columns:
         total_vega, vega_by_strike = calculate_total_exposure(df_griegas_for_gex, greek_col='Vega')
         if total_vega is not None:
-            print(f"Total Vega Exposure: {total_vega}")
+            print(f"Total Vega Exposure: {total_vega:,.0f}")
         if vega_by_strike is not None: print(vega_by_strike.head())
     else:
         print("Vega column not found in sample data for Vega exposure calculation.")
@@ -362,7 +364,7 @@ if __name__ == '__main__':
     if 'Theta' in df_griegas_for_gex.columns:
         total_theta, theta_by_strike = calculate_total_exposure(df_griegas_for_gex, greek_col='Theta')
         if total_theta is not None:
-            print(f"Total Theta Exposure: {total_theta}") # Expected to be negative
+            print(f"Total Theta Exposure: {total_theta:,.0f}")
         if theta_by_strike is not None: print(theta_by_strike.head())
     else:
         print("Theta column not found for Theta exposure calculation.")


### PR DESCRIPTION
- Refined `calculate_black_scholes_gamma` in `calculations.py` to correctly handle cases where the spot price (S) is a scalar and other parameters (K, T, sigma) are arrays. This resolves an IndexError caused by attempting to index a 0-dimensional array (scalar S) with a 1-dimensional mask.
- Added more robust input validation and NaN handling within `calculate_black_scholes_gamma` for edge cases (e.g., T=0, sigma=0).
- Ensured `calculate_gex_analytics` correctly prepares and passes data (using .values for arrays) to the updated gamma function for both current GEX calculation and simulated GEX curve generation.